### PR TITLE
thermal: imx: Introduce cooldown hysteresis

### DIFF
--- a/drivers/thermal/imx_thermal.c
+++ b/drivers/thermal/imx_thermal.c
@@ -20,7 +20,7 @@
 #include <imx_thermal.h>
 
 /* board will busyloop until this many degrees C below CPU max temperature */
-#define TEMPERATURE_HOT_DELTA   5 /* CPU maxT - 5C */
+#define TEMPERATURE_HOT_DELTA   15 /* CPU maxT - 15C */
 #define FACTOR0			10000000
 #define FACTOR1			15423
 #define FACTOR2			4148468


### PR DESCRIPTION
The calculation of critical temperature and its behavior is identical between U-Boot and Linux imx thermal ( critical = maxC - 5C ). This is problematic because of the following reasons:
* U-Boot usually runs with a lower clock frequency and less parallel tasks in comparision to a Linux boot
* thermal management is not available at the very begin of Linux boot
* A/B boot don't expect thermal shutdown during Linux boot, which is considered as a failure in the boot image

Because of this, U-Boot must ensure that there is a temperature reserve to finish the Linux boot without triggering a thermal shutdown. Otherwise this could lead to some kind of swinging between U-Boot and Linux or even worse a real CPU shutdown. An additional hysteresis of 10 degress is considered enough.
